### PR TITLE
fix: Add GitHub Actions permissions for model auto-commit

### DIFF
--- a/.github/workflows/ml-pipeline.yml
+++ b/.github/workflows/ml-pipeline.yml
@@ -1,5 +1,10 @@
 name: ML Model Training & Validation
 
+# Add permissions for GitHub Actions to write to repository
+permissions:
+  contents: write
+  actions: read
+
 on:
   schedule:
     # Run weekly on Sundays at 02:00 UTC for model retraining


### PR DESCRIPTION
- Add 'contents: write' permission to allow GitHub Actions to push commits
- Add 'actions: read' permission for workflow operations
- Resolves: 'Permission to sengar-ajay/MLOps.git denied to github-actions[bot]'
- Enables automatic model updates after training completion

The workflow can now successfully commit trained models back to repository.